### PR TITLE
Only get list of repositories on 1st run and save OS release version.

### DIFF
--- a/roles/satellite_migration/tasks/check_connectivity.yaml
+++ b/roles/satellite_migration/tasks/check_connectivity.yaml
@@ -1,0 +1,7 @@
+---
+- name: "Check that we can connect to the new Satellite / Capsule : {{ satellite_migration_url }}"
+  uri:
+    url: "{{ satellite_migration_url }}/"
+    validate_certs: false
+    method: "GET"
+    status_code: 200

--- a/roles/satellite_migration/tasks/deregister.yaml
+++ b/roles/satellite_migration/tasks/deregister.yaml
@@ -12,7 +12,7 @@
 
   - name: Uninstall old the Katello RPM
     yum:
-      name: "katello-ca-consumer-latest"
+      name: "katello-ca-consumer*"
       state: absent
 
 - name: Remove host from old Satellite

--- a/roles/satellite_migration/tasks/deregister.yaml
+++ b/roles/satellite_migration/tasks/deregister.yaml
@@ -11,9 +11,13 @@
     shell: /usr/bin/subscription-manager clean
 
   - name: Uninstall old the Katello RPM
-    yum:
-      name: "katello-ca-consumer*"
-      state: absent
+    # Some 'yum' Ansible module versions fail when using a glob.
+    # We are using the shell as a workaround.
+    #yum:
+    #  name: "katello-ca-consumer*"
+    #  state: absent
+    shell: "yum erase -y 'katello-ca-consumer*'"
+    ignore_errors: true
 
 - name: Remove host from old Satellite
   uri:

--- a/roles/satellite_migration/tasks/get_repositories.yaml
+++ b/roles/satellite_migration/tasks/get_repositories.yaml
@@ -16,12 +16,13 @@
     state: present
     line: "{{ item }}"
   loop: "{{ repositories.stdout_lines }}"
-  when: repoconfig.stat.exists == False
+  when: repoconfig.stat.exists == false
 
 - name: Get subscription release (if set)
   shell: "LC_ALL=C subscription-manager release"
   register: cmd
-  changed_when: False
+  changed_when: false
+  failed_when: false
 
 - name: Write subscription release
   lineinfile:
@@ -29,4 +30,6 @@
     create: true
     state: present
     line: "{{ cmd.stdout }}"
-  when: cmd.stdout != 'Release not set'
+  when: 
+  - cmd.rc == 0
+  - cmd.stdout != 'Release not set'

--- a/roles/satellite_migration/tasks/get_repositories.yaml
+++ b/roles/satellite_migration/tasks/get_repositories.yaml
@@ -1,9 +1,13 @@
 ---
-
 - name: Get repository list
   shell: "subscription-manager repos --list-enabled | grep -P '^Repo ID:' |  awk -F : '{print $2 }' | sed 's/ //g'"
   become: true
   register: repositories
+
+- name: Check if there is a repository configuration backup
+  stat:
+    path: /tmp/repositories.tmp
+  register: repoconfig
 
 - name: Backup repositories to tmp
   lineinfile:
@@ -12,3 +16,17 @@
     state: present
     line: "{{ item }}"
   loop: "{{ repositories.stdout_lines }}"
+  when: repoconfig.stat.exists == False
+
+- name: Get subscription release (if set)
+  shell: "LC_ALL=C subscription-manager release"
+  register: cmd
+  changed_when: False
+
+- name: Write subscription release
+  lineinfile:
+    path: /tmp/subscription-manager-release.tmp
+    create: true
+    state: present
+    line: "{{ cmd.stdout }}"
+  when: cmd.stdout != 'Release not set'

--- a/roles/satellite_migration/tasks/main.yaml
+++ b/roles/satellite_migration/tasks/main.yaml
@@ -1,3 +1,6 @@
+- name: Check connectivity
+  include_tasks: check_connectivity.yaml
+
 - name: Get Repositories
   include_tasks: get_repositories.yaml
   when: satellite_migration_keep_repositories

--- a/roles/satellite_migration/tasks/register.yaml
+++ b/roles/satellite_migration/tasks/register.yaml
@@ -8,7 +8,7 @@
   when: hostvars['localhost']['satellite_registration_command'] is not defined
 
 - name: Execute Satellite registration command
-  shell: "export LANG=en && {{ hostvars['localhost']['satellite_registration_command'] }}"
+  shell: "export LANG=en && unset http_proxy && unset HTTP_PROXY && unset https_proxy && unset HTTPS_PROXY && {{ hostvars['localhost']['satellite_registration_command'] }}"
   become: true
   register: satellite_registration_execution_result
 

--- a/roles/satellite_migration/tasks/set_repositories.yaml
+++ b/roles/satellite_migration/tasks/set_repositories.yaml
@@ -1,8 +1,16 @@
 ---
-
 - name: Enable repositories
   rhsm_repository:
     name: "{{ item }}"
     state: enabled
   become: true
   loop: "{{ repositories.stdout_lines }}"
+
+- name: Check if there is a specific release configuration
+  stat:
+    path: "/tmp/subscription-manager-release.tmp"
+  register: releaseverfile
+
+- name: Set subscription-manager release
+  shell: "subscription-manager release --set $(cat /tmp/subscription-manager-release.tmp | awk '{print $NF}')"
+  when: releaseverfile.stat.exists


### PR DESCRIPTION
This change saves the configured OS release (if any) and applies it later on in the registration process.